### PR TITLE
fixed variable name for flowlogs_s3_logging_bucket_name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -500,7 +500,7 @@ resource "aws_s3_bucket" "flowlogs_to_s3" {
   }
 
   logging {
-    target_bucket = "${var.s3_logging_bucket_name}"
+    target_bucket = "${var.flowlogs_s3_logging_bucket_name}"
     target_prefix = "${module.flowlogs_to_s3_naming.name}/"
   }
 


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at: https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
--->
Fixes #34

variable name mismatch for FlowLogs s3 logging bucket referenced in the module and in variables


***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-vpc/blob/master/CHANGELOG.md):
<!--
If the changes are not user-facing, just write "NONE" in the release-note block below.
-->

```release-note

BUG FIXES:

* Fix variable mismatch `flowlogs_s3_logging_bucket_name`
```

***

The output from the `terraform plan` command from the changes you propose.

```
$ terraform plan
```

<!---
Credit: 
This template is a modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
